### PR TITLE
Run tests that modify PUBLISH_OUTPUT_LOCATION sequentially

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -137,9 +137,11 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Expect(ioutil.WriteFile(filepath.Join(layersDir, "publish-output-location", "some-app"), nil, os.ModePerm)).To(Succeed())
 				os.Setenv("PUBLISH_OUTPUT_LOCATION", filepath.Join(layersDir, "publish-output-location"))
 			})
+
 			it.After(func() {
 				os.Unsetenv("PUBLISH_OUTPUT_LOCATION")
 			})
+
 			it("returns a result that builds correctly", func() {
 				result, err := build(packit.BuildContext{
 					WorkingDir: workingDir,
@@ -180,9 +182,11 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Expect(ioutil.WriteFile(filepath.Join(layersDir, "publish-output-location", "some-app.dll"), nil, os.ModePerm)).To(Succeed())
 				os.Setenv("PUBLISH_OUTPUT_LOCATION", filepath.Join(layersDir, "publish-output-location"))
 			})
+
 			it.After(func() {
 				os.Unsetenv("PUBLISH_OUTPUT_LOCATION")
 			})
+
 			it("returns a result that builds correctly", func() {
 				result, err := build(packit.BuildContext{
 					WorkingDir: workingDir,
@@ -214,7 +218,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					},
 				}))
 			})
-		})
+		}, spec.Sequential())
 	})
 
 	context("failure cases", func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with -->

<!-- A short explanation of the proposed change -->
## Summary
Resolves a race condition in the unit tests where the value of the `PUBLISH_OUTPUT_LOCATION` environment variable was being set for tests that are running in parallel. As the test run in parallel, the value of `PUBLISH_OUTPUT_LOCATION` is non-deterministic and leads to intermittent failures. This change is to isolate and run that set of tests sequentially so that the global value of `PUBLISH_OUTPUT_LOCATION` does not impact other tests in the suite.

<!-- Please confirm the following -->
# Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
