### PR TITLE
Strips *.runtimeconfig.json file of comments before parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.14
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/gravityblast/go-jsmin v0.0.0-20141027113318-a32d741b3595
 	github.com/onsi/gomega v1.10.3
 	github.com/paketo-buildpacks/occam v0.0.20
 	github.com/paketo-buildpacks/packit v0.4.1
+	github.com/pilu/miniassert v0.0.0-20140522125902-bee63581261a // indirect
 	github.com/sclevine/spec v1.4.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gravityblast/go-jsmin v0.0.0-20141027113318-a32d741b3595 h1:JIiw2lWw1ZnMEPhepCyblvAEmb5+/dYfAmrvs69bKGQ=
+github.com/gravityblast/go-jsmin v0.0.0-20141027113318-a32d741b3595/go.mod h1:UTAY+ft90OvGhUIlsW/cxIsszhAbyCwGVVDkuyjVz0A=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -333,6 +335,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pilu/miniassert v0.0.0-20140522125902-bee63581261a h1:U8Xgy85P2npR1jqpNF4q9rLSt6kzrOrWubkepc3lWbE=
+github.com/pilu/miniassert v0.0.0-20140522125902-bee63581261a/go.mod h1:QKd9TvGj31l6g+MV2PqthhK68d5ZPv/Q2PvtsS0mM3I=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/runtime_config_parser.go
+++ b/runtime_config_parser.go
@@ -1,12 +1,15 @@
 package dotnetexecute
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/gravityblast/go-jsmin"
 )
 
 type RuntimeConfig struct {
@@ -56,7 +59,13 @@ func (p RuntimeConfigParser) Parse(glob string) (RuntimeConfig, error) {
 	}
 	defer file.Close()
 
-	err = json.NewDecoder(file).Decode(&data)
+	buffer := bytes.NewBuffer(nil)
+	err = jsmin.Min(file, buffer)
+	if err != nil {
+		return RuntimeConfig{}, err
+	}
+
+	err = json.NewDecoder(buffer).Decode(&data)
 	if err != nil {
 		return RuntimeConfig{}, err
 	}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with -->

<!-- A short explanation of the proposed change -->
## Summary
Use a JavaScript minifier to strip comments from the `*.runtimeconfig.json` file.

<!-- An explanation of the use cases your change enables -->
## Use cases
This addition will allow the buildpack to parse `*.runtimeconfig.json` files that include comments. Although this is not part of the JSON spec, it seems to be quite common and allowed within the .Net Core community.

<!-- Please confirm the following -->
## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
