### PR TITLE
Place spec.Sequential in the correct context

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -218,8 +218,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					},
 				}))
 			})
-		}, spec.Sequential())
-	})
+		})
+	}, spec.Sequential())
 
 	context("failure cases", func() {
 		context("runtime config not present", func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with -->

<!-- A short explanation of the proposed change -->
## Summary
Moves the `spec.Sequential` invocation that resolves the race condition when setting `PUBLISH_OUTPUT_LOCATION` to the correct context block.

<!-- Please confirm the following -->
## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
