### PR TITLE
Change provides from "build" to "dotnet-application"

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -105,8 +105,7 @@ func Detect(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser,
 			}
 
 			requirements = append(requirements, packit.BuildPlanRequirement{
-				// later todo: change to dotnet-application after dotnet-publish cnb is done
-				Name: "build",
+				Name: "dotnet-application",
 				Metadata: map[string]interface{}{
 					"launch": true,
 				},

--- a/detect_test.go
+++ b/detect_test.go
@@ -289,7 +289,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 					{
-						Name: "build",
+						Name: "dotnet-application",
 						Metadata: map[string]interface{}{
 							"launch": true,
 						},
@@ -345,7 +345,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 					{
-						Name: "build",
+						Name: "dotnet-application",
 						Metadata: map[string]interface{}{
 							"launch": true,
 						},
@@ -396,7 +396,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 					{
-						Name: "build",
+						Name: "dotnet-application",
 						Metadata: map[string]interface{}{
 							"launch": true,
 						},
@@ -468,7 +468,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							},
 						},
 						{
-							Name: "build",
+							Name: "dotnet-application",
 							Metadata: map[string]interface{}{
 								"launch": true,
 							},


### PR DESCRIPTION
Per RFC0001

This integration tests will succeed once https://github.com/paketo-buildpacks/dotnet-publish/pull/112 is merged and a new release of `dotnet-publish` is available.
