### PR TITLE
Only require the dotnet-sdk if there is no FDE

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -66,14 +66,16 @@ func Detect(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser,
 			})
 
 			// Only make SDK available at launch if there is no executable (FDD case only)
-			requirements = append(requirements, packit.BuildPlanRequirement{
-				Name: "dotnet-sdk",
-				Metadata: map[string]interface{}{
-					"version":        getSDKVersion(config.Version),
-					"version-source": filepath.Base(config.Path),
-					"launch":         !config.Executable,
-				},
-			})
+			if !config.Executable {
+				requirements = append(requirements, packit.BuildPlanRequirement{
+					Name: "dotnet-sdk",
+					Metadata: map[string]interface{}{
+						"version":        getSDKVersion(config.Version),
+						"version-source": filepath.Base(config.Path),
+						"launch":         true,
+					},
+				})
+			}
 
 			if config.UsesASPNet {
 				requirements = append(requirements, packit.BuildPlanRequirement{

--- a/detect_test.go
+++ b/detect_test.go
@@ -103,14 +103,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 								"launch":         true,
 							},
 						},
-						{
-							Name: "dotnet-sdk",
-							Metadata: map[string]interface{}{
-								"version":        "2.1.*",
-								"version-source": "some-app.runtimeconfig.json",
-								"launch":         false,
-							},
-						},
 					},
 				}))
 			})
@@ -188,14 +180,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 								"version":        "2.1.0",
 								"version-source": "some-app.runtimeconfig.json",
 								"launch":         true,
-							},
-						},
-						{
-							Name: "dotnet-sdk",
-							Metadata: map[string]interface{}{
-								"version":        "2.1.*",
-								"version-source": "some-app.runtimeconfig.json",
-								"launch":         false,
 							},
 						},
 						{

--- a/integration/fde_aspnet_test.go
+++ b/integration/fde_aspnet_test.go
@@ -63,7 +63,6 @@ func testFdeASPNet(t *testing.T, context spec.G, it spec.S) {
 					settings.Buildpacks.ICU.Online,
 					settings.Buildpacks.DotnetCoreRuntime.Online,
 					settings.Buildpacks.DotnetCoreASPNet.Online,
-					settings.Buildpacks.DotnetCoreSDK.Online,
 					settings.Buildpacks.DotnetExecute.Online,
 				).
 				Execute(name, source)

--- a/integration/framework_dependent_executable_test.go
+++ b/integration/framework_dependent_executable_test.go
@@ -60,7 +60,6 @@ func testFrameworkDependentExecutable(t *testing.T, context spec.G, it spec.S) {
 				WithBuildpacks(
 					settings.Buildpacks.ICU.Online,
 					settings.Buildpacks.DotnetCoreRuntime.Online,
-					settings.Buildpacks.DotnetCoreSDK.Online,
 					settings.Buildpacks.DotnetExecute.Online,
 				).
 				Execute(name, source)


### PR DESCRIPTION
Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:
Makes sure that the SDK is only required is if the app is and FDD. 

Please confirm the following:
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
