### PR TITLE
Use version-source as *sproj or runtimeconfig.json, rm-ing app name

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -60,7 +60,7 @@ func Detect(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser,
 				Name: "dotnet-runtime",
 				Metadata: map[string]interface{}{
 					"version":        config.Version,
-					"version-source": filepath.Base(config.Path),
+					"version-source": "runtimeconfig.json",
 					"launch":         true,
 				},
 			})
@@ -71,7 +71,7 @@ func Detect(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser,
 					Name: "dotnet-sdk",
 					Metadata: map[string]interface{}{
 						"version":        getSDKVersion(config.Version),
-						"version-source": filepath.Base(config.Path),
+						"version-source": "runtimeconfig.json",
 						"launch":         true,
 					},
 				})
@@ -83,7 +83,7 @@ func Detect(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser,
 					Name: "dotnet-aspnetcore",
 					Metadata: map[string]interface{}{
 						"version":        config.Version,
-						"version-source": filepath.Base(config.Path),
+						"version-source": "runtimeconfig.json",
 						"launch":         true,
 					},
 				})
@@ -117,7 +117,7 @@ func Detect(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser,
 				Name: "dotnet-runtime",
 				Metadata: map[string]interface{}{
 					"version":        version,
-					"version-source": filepath.Base(projectFile),
+					"version-source": "*sproj",
 					"launch":         true,
 				},
 			})
@@ -126,7 +126,7 @@ func Detect(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser,
 				Name: "dotnet-sdk",
 				Metadata: map[string]interface{}{
 					"version":        getSDKVersion(version),
-					"version-source": filepath.Base(projectFile),
+					"version-source": "*sproj",
 					"launch":         true,
 				},
 			})
@@ -141,7 +141,7 @@ func Detect(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser,
 					Name: "dotnet-aspnetcore",
 					Metadata: map[string]interface{}{
 						"version":        version,
-						"version-source": filepath.Base(projectFile),
+						"version-source": "*sproj",
 						"launch":         true,
 					},
 				})
@@ -156,7 +156,7 @@ func Detect(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser,
 				requirements = append(requirements, packit.BuildPlanRequirement{
 					Name: "node",
 					Metadata: map[string]interface{}{
-						"version-source": filepath.Base(projectFile),
+						"version-source": "*sproj",
 						"launch":         true,
 					},
 				})

--- a/detect_test.go
+++ b/detect_test.go
@@ -99,7 +99,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: "dotnet-runtime",
 							Metadata: map[string]interface{}{
 								"version":        "2.1.0",
-								"version-source": "some-app.runtimeconfig.json",
+								"version-source": "runtimeconfig.json",
 								"launch":         true,
 							},
 						},
@@ -134,7 +134,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: "dotnet-runtime",
 							Metadata: map[string]interface{}{
 								"version":        "2.1.0",
-								"version-source": "some-app.runtimeconfig.json",
+								"version-source": "runtimeconfig.json",
 								"launch":         true,
 							},
 						},
@@ -142,7 +142,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: "dotnet-sdk",
 							Metadata: map[string]interface{}{
 								"version":        "2.1.*",
-								"version-source": "some-app.runtimeconfig.json",
+								"version-source": "runtimeconfig.json",
 								"launch":         true,
 							},
 						},
@@ -178,7 +178,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: "dotnet-runtime",
 							Metadata: map[string]interface{}{
 								"version":        "2.1.0",
-								"version-source": "some-app.runtimeconfig.json",
+								"version-source": "runtimeconfig.json",
 								"launch":         true,
 							},
 						},
@@ -186,7 +186,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: "dotnet-aspnetcore",
 							Metadata: map[string]interface{}{
 								"version":        "2.1.0",
-								"version-source": "some-app.runtimeconfig.json",
+								"version-source": "runtimeconfig.json",
 								"launch":         true,
 							},
 						},
@@ -222,7 +222,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: "dotnet-runtime",
 							Metadata: map[string]interface{}{
 								"version":        "2.1.0",
-								"version-source": "some-app.runtimeconfig.json",
+								"version-source": "runtimeconfig.json",
 								"launch":         true,
 							},
 						},
@@ -230,7 +230,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: "dotnet-sdk",
 							Metadata: map[string]interface{}{
 								"version":        "2.1.*",
-								"version-source": "some-app.runtimeconfig.json",
+								"version-source": "runtimeconfig.json",
 								"launch":         true,
 							},
 						},
@@ -238,7 +238,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: "dotnet-aspnetcore",
 							Metadata: map[string]interface{}{
 								"version":        "2.1.0",
-								"version-source": "some-app.runtimeconfig.json",
+								"version-source": "runtimeconfig.json",
 								"launch":         true,
 							},
 						},
@@ -282,7 +282,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Name: "dotnet-runtime",
 						Metadata: map[string]interface{}{
 							"version":        "*",
-							"version-source": "some-app.csproj",
+							"version-source": "*sproj",
 							"launch":         true,
 						},
 					},
@@ -290,7 +290,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Name: "dotnet-sdk",
 						Metadata: map[string]interface{}{
 							"version":        "*",
-							"version-source": "some-app.csproj",
+							"version-source": "*sproj",
 							"launch":         true,
 						},
 					},
@@ -338,7 +338,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Name: "dotnet-runtime",
 						Metadata: map[string]interface{}{
 							"version":        "3.1.*",
-							"version-source": "some-app.csproj",
+							"version-source": "*sproj",
 							"launch":         true,
 						},
 					},
@@ -346,7 +346,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Name: "dotnet-sdk",
 						Metadata: map[string]interface{}{
 							"version":        "3.1.*",
-							"version-source": "some-app.csproj",
+							"version-source": "*sproj",
 							"launch":         true,
 						},
 					},
@@ -389,7 +389,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Name: "dotnet-runtime",
 						Metadata: map[string]interface{}{
 							"version":        "3.1.*",
-							"version-source": "some-app.csproj",
+							"version-source": "*sproj",
 							"launch":         true,
 						},
 					},
@@ -397,14 +397,14 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Name: "dotnet-sdk",
 						Metadata: map[string]interface{}{
 							"version":        "3.1.*",
-							"version-source": "some-app.csproj",
+							"version-source": "*sproj",
 							"launch":         true,
 						},
 					},
 					{
 						Name: "node",
 						Metadata: map[string]interface{}{
-							"version-source": "some-app.csproj",
+							"version-source": "*sproj",
 							"launch":         true,
 						},
 					},
@@ -461,7 +461,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: "dotnet-runtime",
 							Metadata: map[string]interface{}{
 								"version":        "*",
-								"version-source": "some-app.csproj",
+								"version-source": "*sproj",
 								"launch":         true,
 							},
 						},
@@ -469,7 +469,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: "dotnet-sdk",
 							Metadata: map[string]interface{}{
 								"version":        "*",
-								"version-source": "some-app.csproj",
+								"version-source": "*sproj",
 								"launch":         true,
 							},
 						},


### PR DESCRIPTION
Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:
Resolves #115 

* An explanation of the use cases your change enables:

Please confirm the following:
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
