### PR TITLE
Removes unneeded launch true flag

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -73,7 +73,6 @@ func Detect(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser,
 					Metadata: map[string]interface{}{
 						"version":        getSDKVersion(config.Version),
 						"version-source": "runtimeconfig.json",
-						"launch":         true,
 					},
 				})
 			}
@@ -127,7 +126,6 @@ func Detect(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser,
 				Metadata: map[string]interface{}{
 					"version":        getSDKVersion(version),
 					"version-source": "project file",
-					"launch":         true,
 				},
 			})
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -150,7 +150,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Metadata: map[string]interface{}{
 								"version":        "2.1.*",
 								"version-source": "runtimeconfig.json",
-								"launch":         true,
 							},
 						},
 					},
@@ -249,7 +248,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Metadata: map[string]interface{}{
 							"version":        "*",
 							"version-source": "project file",
-							"launch":         true,
 						},
 					},
 				},
@@ -303,7 +301,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Metadata: map[string]interface{}{
 							"version":        "3.1.*",
 							"version-source": "project file",
-							"launch":         true,
 						},
 					},
 				},
@@ -358,7 +355,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Metadata: map[string]interface{}{
 							"version":        "3.1.*",
 							"version-source": "project file",
-							"launch":         true,
 						},
 					},
 					{
@@ -421,7 +417,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Metadata: map[string]interface{}{
 							"version":        "3.1.*",
 							"version-source": "project file",
-							"launch":         true,
 						},
 					},
 					{


### PR DESCRIPTION
## Summary
<!-- A short explanation of the proposed change -->
We shouldn't be requiring these build plan entries for launch as we won't need the whole SDK at that point.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
