### PR TITLE
Removes extraneous buildpack.yml references in integration tests

### DIFF
--- a/integration/testdata/source_5_app/buildpack.yml
+++ b/integration/testdata/source_5_app/buildpack.yml
@@ -1,2 +1,0 @@
-dotnet-core:
-  sdk: 3.1.x

--- a/integration/testdata/source_app/buildpack.yml
+++ b/integration/testdata/source_app/buildpack.yml
@@ -1,2 +1,0 @@
-dotnet-core:
-  sdk: 3.1.x


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This buildpack does not have any dependence on a `buildpack.yml` file, but its test included a couple of instances where they existed, but did not appear to be germane to the assertions of the test. I have removed those references so that we do not confuse them as relevant parts of the test suite.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
