### PR TITLE
fix version line parser

### DIFF
--- a/project_file_parser.go
+++ b/project_file_parser.go
@@ -68,7 +68,7 @@ func (p ProjectFileParser) ParseVersion(path string) (string, error) {
 
 	// This regular expression matches on 'net<x>.<y>',
 	// 'net<x>.<y>-<platform>' & 'netcoreapp<x>.<y>'
-	targetFrameworkRe := regexp.MustCompile(`net(?:coreapp)?(\d\.\d)(?:\w+)?`)
+	targetFrameworkRe := regexp.MustCompile(`net(?:coreapp)?(?:(\d\.\d)(?:\-?\w+)?)$`)
 	for _, group := range project.PropertyGroups {
 		matches := targetFrameworkRe.FindStringSubmatch(group.TargetFramework)
 		if len(matches) == 2 {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This addresses the issue outlined [here](https://github.com/paketo-buildpacks/dotnet-core/issues/440), where it seems like the version line parser was allowing certain lines that shouldn't have been passing.
## Use Cases
<!-- An explanation of the use cases your change enables -->
This change should allow users to get more direct error messages when building their apps with custom framework versions
## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
