### PR TITLE
Enable Live Reloading w watchexec

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/paketo-buildpacks/packit"
@@ -54,6 +55,21 @@ func Detect(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser,
 					"launch": true,
 				},
 			},
+		}
+
+		if reload, ok := os.LookupEnv("BP_LIVE_RELOAD_ENABLED"); ok {
+			shouldEnableReload, err := strconv.ParseBool(reload)
+			if err != nil {
+				return packit.DetectResult{}, fmt.Errorf("failed to parse BP_LIVE_RELOAD_ENABLED: %w", err)
+			}
+			if shouldEnableReload {
+				requirements = append(requirements, packit.BuildPlanRequirement{
+					Name: "watchexec",
+					Metadata: map[string]interface{}{
+						"launch": true,
+					},
+				})
+			}
 		}
 
 		config, err := configParser.Parse(filepath.Join(root, "*.runtimeconfig.json"))

--- a/integration.json
+++ b/integration.json
@@ -1,8 +1,9 @@
 {
+  "dotnet-core-aspnet": "github.com/paketo-buildpacks/dotnet-core-aspnet",
   "dotnet-core-runtime": "github.com/paketo-buildpacks/dotnet-core-runtime",
   "dotnet-core-sdk": "github.com/paketo-buildpacks/dotnet-core-sdk",
-  "dotnet-core-aspnet": "github.com/paketo-buildpacks/dotnet-core-aspnet",
   "dotnet-publish": "github.com/paketo-buildpacks/dotnet-publish",
   "icu": "github.com/paketo-buildpacks/icu",
-  "node-engine": "github.com/paketo-buildpacks/node-engine"
+  "node-engine": "github.com/paketo-buildpacks/node-engine",
+  "watchexec": "github.com/paketo-buildpacks/watchexec"
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -27,6 +27,7 @@ var settings struct {
 		DotnetCoreASPNet  string `json:"dotnet-core-aspnet"`
 		DotnetPublish     string `json:"dotnet-publish"`
 		NodeEngine        string `json:"node-engine"`
+		Watchexec         string `json:"watchexec"`
 	}
 	Buildpacks struct {
 		DotnetExecute struct {
@@ -48,6 +49,9 @@ var settings struct {
 			Online string
 		}
 		NodeEngine struct {
+			Online string
+		}
+		Watchexec struct {
 			Online string
 		}
 	}
@@ -101,6 +105,10 @@ func TestIntegration(t *testing.T) {
 
 	settings.Buildpacks.NodeEngine.Online, err = buildpackStore.Get.
 		Execute(settings.Config.NodeEngine)
+	Expect(err).ToNot(HaveOccurred())
+
+	settings.Buildpacks.Watchexec.Online, err = buildpackStore.Get.
+		Execute(settings.Config.Watchexec)
 	Expect(err).ToNot(HaveOccurred())
 
 	SetDefaultEventuallyTimeout(10 * time.Second)


### PR DESCRIPTION
## Summary
<!-- A short explanation of the proposed change -->
Adds logic for requiring the `watchexec` buildpack and optionally setting a start command which invokes the app with `watchexec`. 
Resolves #241 

## Use Cases
<!-- An explanation of the use cases your change enables -->
Per [this RFC](https://github.com/paketo-buildpacks/rfcs/blob/main/text/0032-reloadable-process-types.md), allows app container processes to be reloaded when file changes occur.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
