### PR TITLE
Bumps buildpack API to 0.6

### DIFF
--- a/build.go
+++ b/build.go
@@ -51,6 +51,7 @@ func Build(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser, 
 			{
 				Type:    "web",
 				Command: command,
+				Default: true,
 			},
 		}
 
@@ -65,6 +66,7 @@ func Build(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser, 
 					{
 						Type:    "web",
 						Command: fmt.Sprintf(`watchexec --restart --watch %s "%s"`, context.WorkingDir, command),
+						Default: true,
 					},
 					{
 						Type:    "no-reload",

--- a/build_test.go
+++ b/build_test.go
@@ -126,6 +126,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: fmt.Sprintf("%s --urls http://0.0.0.0:${PORT:-8080}", filepath.Join(workingDir, "myapp")),
+							Default: true,
 						},
 					},
 				},
@@ -173,6 +174,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: fmt.Sprintf("dotnet %s --urls http://0.0.0.0:${PORT:-8080}", filepath.Join(workingDir, "myapp.dll")),
+							Default: true,
 						},
 					},
 				},
@@ -223,6 +225,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: fmt.Sprintf(`watchexec --restart --watch %s "%s"`, workingDir, startCommand),
+							Default: true,
 						},
 						{
 							Type:    "no-reload",

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/dotnet-execute"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
All buildpacks that have upgraded to the latest version of `packit` should be able to run with buildpack API 0.6.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
