### PR TITLE
Use layer.ExecD to add the port-chooser to the layer

### DIFF
--- a/build.go
+++ b/build.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/paketo-buildpacks/packit/v2"
-	"github.com/paketo-buildpacks/packit/v2/fs"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 )
 
@@ -98,19 +97,7 @@ func Build(buildpackYMLParser BuildpackConfigParser, configParser ConfigParser, 
 			return packit.BuildResult{}, err
 		}
 		portChooserLayer.Launch = true
-
-		in := filepath.Join(context.CNBPath, "bin", "port-chooser")
-		execdDir := filepath.Join(portChooserLayer.Path, "exec.d")
-		err = os.MkdirAll(execdDir, os.ModePerm)
-		if err != nil {
-			return packit.BuildResult{}, err
-		}
-		out := filepath.Join(execdDir, "port-chooser")
-
-		err = fs.Copy(in, out)
-		if err != nil {
-			return packit.BuildResult{}, err
-		}
+		portChooserLayer.ExecD = []string{filepath.Join(context.CNBPath, "bin", "port-chooser")}
 
 		return packit.BuildResult{
 			Layers: []packit.Layer{

--- a/build_test.go
+++ b/build_test.go
@@ -57,6 +57,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			BuildEnv:         packit.Environment{},
 			LaunchEnv:        packit.Environment{},
 			ProcessLaunchEnv: map[string]packit.Environment{},
+			ExecD: []string{
+				filepath.Join(cnbDir, "bin", "port-chooser"),
+			},
 		}
 
 		buffer = bytes.NewBuffer(nil)

--- a/build_test.go
+++ b/build_test.go
@@ -39,8 +39,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		cnbDir, err = os.MkdirTemp("", "cnb")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(os.MkdirAll(filepath.Join(cnbDir, "bin"), os.ModePerm)).NotTo(HaveOccurred())
-		Expect(os.WriteFile(filepath.Join(cnbDir, "bin", "port-chooser"), []byte(""), 0644)).NotTo(HaveOccurred())
 
 		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary
Use layer.ExecD to add the port-chooser to the layer, using new functionality in [packit v2](https://github.com/paketo-buildpacks/packit/releases/tag/v2.2.0)

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
